### PR TITLE
Make brandLogo optional on Android

### DIFF
--- a/android/src/main/kotlin/com/stripe/identity/identity/StripeIdentityPlugin.kt
+++ b/android/src/main/kotlin/com/stripe/identity/identity/StripeIdentityPlugin.kt
@@ -101,7 +101,7 @@ class StripeIdentityPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         val configuration =
             IdentityVerificationSheet.Configuration(
                 // Set the brand logo from the provided URL.
-                brandLogo = brandLogoUrl?.let { Uri.parse(it) }
+                brandLogo = brandLogoUrl?.let { Uri.parse(it) } ?: Uri.EMPTY
             )
 
         // Create an instance of the IdentityVerificationSheet.


### PR DESCRIPTION
Without adding this fallback, when brandLogoUrl is not passed, it throws an error. Ideally it should ignore it instead