### PR TITLE
fix(android): initialize Stripe Identity sheet early and resolve bran…

### DIFF
--- a/android/src/main/kotlin/com/stripe/identity/identity/StripeIdentityPlugin.kt
+++ b/android/src/main/kotlin/com/stripe/identity/identity/StripeIdentityPlugin.kt
@@ -3,8 +3,9 @@ package com.stripe.identity.identity
 import android.app.Activity
 import android.content.Context
 import android.net.Uri
+import android.util.Log
 import androidx.activity.ComponentActivity
-import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.Lifecycle
 import com.stripe.android.identity.IdentityVerificationSheet
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
@@ -18,6 +19,11 @@ import io.flutter.plugin.common.MethodChannel.Result
  * A Flutter plugin for Stripe Identity verification.
  */
 class StripeIdentityPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
+    companion object {
+        private const val TAG = "StripeIdentityPlugin"
+        private const val BRAND_LOGO_META_DATA_KEY = "com.stripe.identity.brand_logo_url"
+    }
+
     /**
      * The Flutter method channel used to communicate with the Flutter application.
      */
@@ -42,16 +48,6 @@ class StripeIdentityPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
      * The result callback to return to Flutter.
      */
     private var pendingResult: Result? = null
-
-    /**
-     * The verification session ID.
-     */
-    private var verificationSessionId: String? = null
-
-    /**
-     * The ephemeral key secret.
-     */
-    private var ephemeralKeySecret: String? = null
 
     /**
      * The brand logo URL.
@@ -80,20 +76,9 @@ class StripeIdentityPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         activity = binding.activity
 
-        // Check if the activity is a ComponentActivity (or FragmentActivity).
+        val activity = activity
         if (activity is ComponentActivity) {
-            // Create a configuration for the IdentityVerificationSheet.
-            val configuration = IdentityVerificationSheet.Configuration(
-                brandLogo = brandLogoUrl?.let { Uri.parse(it) } ?: Uri.EMPTY
-            )
-
-            // Create an instance of the IdentityVerificationSheet.
-            identityVerificationSheet = IdentityVerificationSheet.create(
-                activity as ComponentActivity,
-                configuration
-            ) { verificationFlowResult ->
-                handleVerificationResult(verificationFlowResult, pendingResult)
-            }
+            createIdentityVerificationSheet(activity, brandLogoUrl)
         }
     }
 
@@ -112,6 +97,15 @@ class StripeIdentityPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 val key = call.argument<String>("key")
                 brandLogoUrl = call.argument<String>("brandLogoUrl")
                 val styleMap = call.argument<Map<String, Any>>("style")
+
+                val activity = activity
+                if (activity is ComponentActivity &&
+                    identityVerificationSheet == null &&
+                    activity.lifecycle.currentState.isAtLeast(Lifecycle.State.INITIALIZED) &&
+                    !activity.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+                ) {
+                    createIdentityVerificationSheet(activity, brandLogoUrl)
+                }
 
                 // Start the verification process if the required arguments are provided.
                 if (id != null && key != null) {
@@ -134,7 +128,12 @@ class StripeIdentityPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
      * @param styleMap Optional styling configuration from Flutter.
      * @param result A closure to return the result of the verification flow to Flutter.
      */
-    private fun startVerification(id: String, key: String, styleMap: Map<String, Any>?, result: Result) {
+    private fun startVerification(
+        id: String,
+        key: String,
+        styleMap: Map<String, Any>?,
+        result: Result
+    ) {
         val activity = activity
         if (activity !is ComponentActivity) {
             // Return an error if the activity is not a ComponentActivity.
@@ -143,8 +142,15 @@ class StripeIdentityPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         }
 
         pendingResult = result
-        verificationSessionId = id
-        ephemeralKeySecret = key
+
+        if (identityVerificationSheet == null) {
+            result.error(
+                "NO_SHEET",
+                "Identity sheet is not initialized. Ensure plugin is attached before starting verification.",
+                null
+            )
+            return
+        }
 
         // Present the verification sheet on the UI thread.
         activity.runOnUiThread {
@@ -154,6 +160,60 @@ class StripeIdentityPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 // Set the ephemeral key secret.
                 ephemeralKeySecret = key
             )
+        }
+    }
+
+    private fun createIdentityVerificationSheet(activity: ComponentActivity, brandLogoUrl: String?) {
+        val resolvedBrandLogoUri = resolveBrandLogoUri(activity, brandLogoUrl)
+
+        val configuration = IdentityVerificationSheet.Configuration(
+            brandLogo = resolvedBrandLogoUri
+        )
+
+        identityVerificationSheet = IdentityVerificationSheet.create(
+            activity,
+            configuration
+        ) { verificationFlowResult ->
+            handleVerificationResult(verificationFlowResult, pendingResult)
+        }
+
+        Log.d(TAG, "Identity sheet initialized with brand logo URI: $resolvedBrandLogoUri")
+    }
+
+    private fun resolveBrandLogoUri(activity: ComponentActivity, runtimeBrandLogoUrl: String?): Uri {
+        runtimeBrandLogoUrl
+            ?.takeIf { it.isNotBlank() }
+            ?.let { return Uri.parse(it) }
+
+        val manifestLogoUrl = try {
+            val appInfo = activity.packageManager.getApplicationInfo(
+                activity.packageName,
+                android.content.pm.PackageManager.GET_META_DATA
+            )
+            appInfo.metaData?.getString(BRAND_LOGO_META_DATA_KEY)
+        } catch (error: Exception) {
+            null
+        }
+
+        manifestLogoUrl
+            ?.takeIf { it.isNotBlank() }
+            ?.let { return Uri.parse(it) }
+
+        return try {
+            val appInfo = activity.packageManager.getApplicationInfo(activity.packageName, 0)
+            val appIconResId = appInfo.icon
+            if (appIconResId != 0) {
+                Uri.Builder()
+                    .scheme("android.resource")
+                    .authority(activity.packageName)
+                    .appendPath(activity.resources.getResourceTypeName(appIconResId))
+                    .appendPath(activity.resources.getResourceEntryName(appIconResId))
+                    .build()
+            } else {
+                Uri.EMPTY
+            }
+        } catch (error: Exception) {
+            Uri.EMPTY
         }
     }
 
@@ -212,6 +272,7 @@ class StripeIdentityPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
      */
     override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
         activity = binding.activity
+        identityVerificationSheet = null
     }
 
     /**


### PR DESCRIPTION
# PR Title
Fix Stripe Identity Android logo initialization timing (brandLogo not shown)

## Summary
This PR fixes an Android lifecycle/configuration issue where the Stripe Identity merchant logo was not rendered, even when a valid `brandLogoUrl` was passed from Flutter.

## What was wrong
On Android, `IdentityVerificationSheet` must be created before the host `Activity` reaches `STARTED`/`RESUMED` because it registers an Activity Result launcher during creation.

The plugin previously had two problematic states:
1. **Original behavior:** created the sheet early enough for lifecycle, but before Flutter method args were available, so `brandLogoUrl` was effectively empty at init time.
2. **First attempted fix:** created the sheet at `startVerification(...)` time to use runtime logo URL, but this caused lifecycle registration errors when called after `RESUMED`.

Result: either no logo (empty URI) or lifecycle crash.

## Root cause
Android Stripe Identity has two constraints that conflict with dynamic per-call logo URLs:
- Sheet creation must happen early in Activity lifecycle.
- `brandLogo` is part of sheet configuration at creation time (not reconfigured per `present(...)` call).

## What changed
- Restored **early sheet initialization** (lifecycle-safe).
- Added deterministic logo resolution at initialization:
  1. runtime URL (if available),
  2. app manifest metadata key,
  3. app icon fallback.
- Added logging for resolved logo URI at sheet initialization.
- Added and documented manifest metadata support:
  - `com.stripe.identity.brand_logo_url`
- Ensured Android app manifest includes explicit `INTERNET` permission for remote logo fetch.

## Why this works
This keeps ActivityResult registration compliant with Android lifecycle requirements while providing a logo URI that is available at initialization time.

## Validation
- Reproduced issue: logo did not render with valid URL.
- Verified lifecycle error when creating sheet late.
- Applied fix and retested with full app restart (no hot reload).
- Confirmed logo now renders correctly.

## Notes
- On Android, per-invocation dynamic `brandLogoUrl` is lifecycle-constrained by Stripe SDK registration behavior.
- Manifest-level logo configuration is the stable source of truth unless plugin architecture is redesigned around pre-registration variants.